### PR TITLE
config initializers for heroku

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,6 @@ module Poseidon
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+    config.assets.initialize_on_precompile = false
   end
 end

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,6 +1,6 @@
 Geocoder.configure(
   # Geocoding options
-  timeout: 3,    
+  timeout: 25,
   # lookup: :nominatim,         # name of geocoding service (symbol)
   # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
   # language: :en,              # ISO-639 language code


### PR DESCRIPTION
Reconfigure GeoCoder Gem to timeout after 25 seconds to give it more time

Reconfigure precompiling assets for heroku deploy